### PR TITLE
r1cs-mpc: authenticated-poly: fix receive_bytes signature

### DIFF
--- a/src/r1cs_mpc/authenticated_poly.rs
+++ b/src/r1cs_mpc/authenticated_poly.rs
@@ -427,7 +427,10 @@ mod tests {
             Ok(())
         }
 
-        async fn receive_bytes(&mut self) -> Result<Vec<u8>, MpcNetworkError> {
+        async fn receive_bytes(
+            &mut self,
+            _num_expected: usize,
+        ) -> Result<Vec<u8>, MpcNetworkError> {
             unimplemented!("not used in testing")
         }
 


### PR DESCRIPTION
`receive_bytes` mock impl for `authenticated_poly` seemed to be missing second param