### PR TITLE
r1cs: constraint_system, linear_combination: extract weights from circuit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ hex = "0.3"
 inventory = "0.3"
 rand_chacha = "0.2"
 tokio = { version = "1.12", features = ["macros", "rt-multi-thread"] }
+lazy_static = "1.4"
 
 [features]
 default = ["std", "avx2_backend", "multiprover"]
@@ -60,7 +61,7 @@ name = "range_proof"
 
 [[test]]
 name = "r1cs"
-required-features = ["yoloproofs"]
+required-features = ["multiprover"]
 
 [[test]]
 name = "integration"
@@ -79,7 +80,7 @@ harness = false
 [[bench]]
 name = "r1cs"
 harness = false
-required-features = ["yoloproofs"]
+required-features = ["multiprover"]
 
 [[bench]]
 name = "linear_proof"

--- a/src/r1cs/constraint_system.rs
+++ b/src/r1cs/constraint_system.rs
@@ -52,6 +52,11 @@ pub trait ConstraintSystem {
     /// Used as a profiling metric
     fn num_multipliers(&self) -> usize;
 
+    /// Fetch the constraints in the system
+    ///
+    /// Used so that they can be exported
+    fn get_constraints(&self) -> &Vec<LinearCombination>;
+
     /// Allocate a single variable.
     ///
     /// This either allocates a new multiplier and returns its `left` variable,

--- a/src/r1cs/linear_combination.rs
+++ b/src/r1cs/linear_combination.rs
@@ -147,29 +147,29 @@ impl LinearCombination {
         // Each LC can have up to `n` non-zero terms of each variable
         // and a single constant
 
-        let mut w_l_row = Vec::new();
-        let mut w_r_row = Vec::new();
-        let mut w_o_row = Vec::new();
-        let mut w_v_row = Vec::new();
+        let mut w_l_row = SparseWeightRow(Vec::new());
+        let mut w_r_row = SparseWeightRow(Vec::new());
+        let mut w_o_row = SparseWeightRow(Vec::new());
+        let mut w_v_row = SparseWeightRow(Vec::new());
         let mut c = Scalar::zero();
 
         for (&var, &coeff) in &self.terms {
             if coeff != Scalar::zero() {
                 match var {
                     Variable::MultiplierLeft(i) => {
-                        w_l_row.push((i, coeff));
+                        w_l_row.0.push((i, coeff));
                     }
                     Variable::MultiplierRight(i) => {
-                        w_r_row.push((i, coeff));
+                        w_r_row.0.push((i, coeff));
                     }
                     Variable::MultiplierOutput(i) => {
-                        w_o_row.push((i, coeff));
+                        w_o_row.0.push((i, coeff));
                     }
                     Variable::Committed(i) => {
-                        w_v_row.push((i, coeff));
+                        w_v_row.0.push((i, -coeff));
                     }
                     Variable::One() => {
-                        c = coeff;
+                        c = -coeff;
                     }
                     Variable::Zero() => {}
                 }

--- a/src/r1cs/linear_combination.rs
+++ b/src/r1cs/linear_combination.rs
@@ -142,7 +142,7 @@ impl LinearCombination {
         SparseWeightRow,
         SparseWeightRow,
         SparseWeightRow,
-        Scalar,
+        Option<Scalar>,
     ) {
         // Each LC can have up to `n` non-zero terms of each variable
         // and a single constant
@@ -151,30 +151,29 @@ impl LinearCombination {
         let mut w_r_row = SparseWeightRow(Vec::new());
         let mut w_o_row = SparseWeightRow(Vec::new());
         let mut w_v_row = SparseWeightRow(Vec::new());
-        let mut c = Scalar::zero();
+        let mut c = None;
 
-        for (&var, &coeff) in &self.terms {
-            if coeff != Scalar::zero() {
-                match var {
-                    Variable::MultiplierLeft(i) => {
-                        w_l_row.0.push((i, coeff));
-                    }
-                    Variable::MultiplierRight(i) => {
-                        w_r_row.0.push((i, coeff));
-                    }
-                    Variable::MultiplierOutput(i) => {
-                        w_o_row.0.push((i, coeff));
-                    }
-                    Variable::Committed(i) => {
-                        w_v_row.0.push((i, -coeff));
-                    }
-                    Variable::One() => {
-                        c = -coeff;
-                    }
-                    Variable::Zero() => {}
+        self.terms
+            .iter()
+            .filter(|(_, &coeff)| coeff != Scalar::zero())
+            .for_each(|(&var, &coeff)| match var {
+                Variable::MultiplierLeft(i) => {
+                    w_l_row.0.push((i, coeff));
                 }
-            }
-        }
+                Variable::MultiplierRight(i) => {
+                    w_r_row.0.push((i, coeff));
+                }
+                Variable::MultiplierOutput(i) => {
+                    w_o_row.0.push((i, coeff));
+                }
+                Variable::Committed(i) => {
+                    w_v_row.0.push((i, -coeff));
+                }
+                Variable::One() => {
+                    c = Some(-coeff);
+                }
+                Variable::Zero() => {}
+            });
 
         (w_l_row, w_r_row, w_o_row, w_v_row, c)
     }

--- a/src/r1cs/mod.rs
+++ b/src/r1cs/mod.rs
@@ -9,7 +9,8 @@ mod prover;
 mod verifier;
 
 pub use self::constraint_system::{
-    ConstraintSystem, RandomizableConstraintSystem, RandomizedConstraintSystem, SparseReducedMatrix,
+    CircuitWeights, ConstraintSystem, RandomizableConstraintSystem, RandomizedConstraintSystem,
+    SparseReducedMatrix, SparseWeightRow,
 };
 pub use self::linear_combination::{LinearCombination, Variable};
 pub use self::proof::R1CSProof;

--- a/src/r1cs/mod.rs
+++ b/src/r1cs/mod.rs
@@ -9,7 +9,7 @@ mod prover;
 mod verifier;
 
 pub use self::constraint_system::{
-    ConstraintSystem, RandomizableConstraintSystem, RandomizedConstraintSystem,
+    ConstraintSystem, RandomizableConstraintSystem, RandomizedConstraintSystem, SparseReducedMatrix,
 };
 pub use self::linear_combination::{LinearCombination, Variable};
 pub use self::proof::R1CSProof;

--- a/src/r1cs/prover.rs
+++ b/src/r1cs/prover.rs
@@ -99,6 +99,10 @@ impl<'t, 'g> ConstraintSystem for Prover<'t, 'g> {
         self.a_O.len()
     }
 
+    fn get_constraints(&self) -> &Vec<LinearCombination> {
+        &self.constraints
+    }
+
     fn multiply(
         &mut self,
         mut left: LinearCombination,
@@ -222,6 +226,10 @@ impl<'t, 'g> ConstraintSystem for RandomizingProver<'t, 'g> {
 
     fn num_multipliers(&self) -> usize {
         self.prover.num_multipliers()
+    }
+
+    fn get_constraints(&self) -> &Vec<LinearCombination> {
+        self.prover.get_constraints()
     }
 
     fn multiply(

--- a/src/r1cs/prover.rs
+++ b/src/r1cs/prover.rs
@@ -9,8 +9,8 @@ use itertools::Itertools;
 use merlin::Transcript;
 
 use super::{
-    ConstraintSystem, LinearCombination, R1CSProof, RandomizableConstraintSystem,
-    RandomizedConstraintSystem, SparseReducedMatrix, Variable,
+    CircuitWeights, ConstraintSystem, LinearCombination, R1CSProof, RandomizableConstraintSystem,
+    RandomizedConstraintSystem, Variable,
 };
 
 use crate::errors::R1CSError;
@@ -100,20 +100,21 @@ impl<'t, 'g> ConstraintSystem for Prover<'t, 'g> {
         self.a_O.len()
     }
 
-    fn get_weights(
-        &self,
-    ) -> (
-        SparseReducedMatrix,
-        SparseReducedMatrix,
-        SparseReducedMatrix,
-        SparseReducedMatrix,
-        Vec<Scalar>,
-    ) {
+    fn get_weights(&self) -> CircuitWeights {
         // Extract sparse-reduced weights from each constraint to construct the matrices
-        self.constraints
+        let (w_l, w_r, w_o, w_v, c) = self
+            .constraints
             .iter()
             .map(|lc| lc.extract_weights())
-            .multiunzip()
+            .multiunzip();
+
+        CircuitWeights {
+            w_l,
+            w_r,
+            w_o,
+            w_v,
+            c,
+        }
     }
 
     fn multiply(
@@ -241,15 +242,7 @@ impl<'t, 'g> ConstraintSystem for RandomizingProver<'t, 'g> {
         self.prover.num_multipliers()
     }
 
-    fn get_weights(
-        &self,
-    ) -> (
-        SparseReducedMatrix,
-        SparseReducedMatrix,
-        SparseReducedMatrix,
-        SparseReducedMatrix,
-        Vec<Scalar>,
-    ) {
+    fn get_weights(&self) -> CircuitWeights {
         self.prover.get_weights()
     }
 

--- a/src/r1cs/prover.rs
+++ b/src/r1cs/prover.rs
@@ -5,11 +5,12 @@ use clear_on_drop::clear::Clear;
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
 use curve25519_dalek::traits::{Identity, MultiscalarMul};
+use itertools::Itertools;
 use merlin::Transcript;
 
 use super::{
     ConstraintSystem, LinearCombination, R1CSProof, RandomizableConstraintSystem,
-    RandomizedConstraintSystem, Variable,
+    RandomizedConstraintSystem, SparseReducedMatrix, Variable,
 };
 
 use crate::errors::R1CSError;
@@ -99,8 +100,20 @@ impl<'t, 'g> ConstraintSystem for Prover<'t, 'g> {
         self.a_O.len()
     }
 
-    fn get_constraints(&self) -> &Vec<LinearCombination> {
-        &self.constraints
+    fn get_weights(
+        &self,
+    ) -> (
+        SparseReducedMatrix,
+        SparseReducedMatrix,
+        SparseReducedMatrix,
+        SparseReducedMatrix,
+        Vec<Scalar>,
+    ) {
+        // Extract sparse-reduced weights from each constraint to construct the matrices
+        self.constraints
+            .iter()
+            .map(|lc| lc.extract_weights())
+            .multiunzip()
     }
 
     fn multiply(
@@ -228,8 +241,16 @@ impl<'t, 'g> ConstraintSystem for RandomizingProver<'t, 'g> {
         self.prover.num_multipliers()
     }
 
-    fn get_constraints(&self) -> &Vec<LinearCombination> {
-        self.prover.get_constraints()
+    fn get_weights(
+        &self,
+    ) -> (
+        SparseReducedMatrix,
+        SparseReducedMatrix,
+        SparseReducedMatrix,
+        SparseReducedMatrix,
+        Vec<Scalar>,
+    ) {
+        self.prover.get_weights()
     }
 
     fn multiply(

--- a/src/r1cs/prover.rs
+++ b/src/r1cs/prover.rs
@@ -103,9 +103,15 @@ impl<'t, 'g> ConstraintSystem for Prover<'t, 'g> {
     fn get_weights(&self) -> CircuitWeights {
         // Extract sparse-reduced weights from each constraint to construct the matrices
         let (w_l, w_r, w_o, w_v, c) = self
+            // It's important that this iteration is in the correct order of the constraints,
+            // otherwise we'll write the wrong index for the given constant in a constraint
             .constraints
             .iter()
-            .map(|lc| lc.extract_weights())
+            .enumerate()
+            .map(|(i, lc)| {
+                let (w_l_row, w_r_row, w_o_row, w_v_row, c_i) = lc.extract_weights();
+                (w_l_row, w_r_row, w_o_row, w_v_row, (i, c_i))
+            })
             .multiunzip();
 
         CircuitWeights {

--- a/src/r1cs/verifier.rs
+++ b/src/r1cs/verifier.rs
@@ -7,8 +7,8 @@ use itertools::Itertools;
 use merlin::Transcript;
 
 use super::{
-    ConstraintSystem, LinearCombination, R1CSProof, RandomizableConstraintSystem,
-    RandomizedConstraintSystem, SparseReducedMatrix, Variable,
+    CircuitWeights, ConstraintSystem, LinearCombination, R1CSProof, RandomizableConstraintSystem,
+    RandomizedConstraintSystem, Variable,
 };
 
 use crate::errors::R1CSError;
@@ -75,20 +75,21 @@ impl<'t, 'g> ConstraintSystem for Verifier<'t, 'g> {
         self.num_vars
     }
 
-    fn get_weights(
-        &self,
-    ) -> (
-        SparseReducedMatrix,
-        SparseReducedMatrix,
-        SparseReducedMatrix,
-        SparseReducedMatrix,
-        Vec<Scalar>,
-    ) {
+    fn get_weights(&self) -> CircuitWeights {
         // Extract sparse-reduced weights from each constraint to construct the matrices
-        self.constraints
+        let (w_l, w_r, w_o, w_v, c) = self
+            .constraints
             .iter()
             .map(|lc| lc.extract_weights())
-            .multiunzip()
+            .multiunzip();
+
+        CircuitWeights {
+            w_l,
+            w_r,
+            w_o,
+            w_v,
+            c,
+        }
     }
 
     fn multiply(
@@ -193,15 +194,7 @@ impl<'t, 'g> ConstraintSystem for RandomizingVerifier<'t, 'g> {
         self.verifier.num_multipliers()
     }
 
-    fn get_weights(
-        &self,
-    ) -> (
-        SparseReducedMatrix,
-        SparseReducedMatrix,
-        SparseReducedMatrix,
-        SparseReducedMatrix,
-        Vec<Scalar>,
-    ) {
+    fn get_weights(&self) -> CircuitWeights {
         self.verifier.get_weights()
     }
 

--- a/src/r1cs/verifier.rs
+++ b/src/r1cs/verifier.rs
@@ -74,6 +74,10 @@ impl<'t, 'g> ConstraintSystem for Verifier<'t, 'g> {
         self.num_vars
     }
 
+    fn get_constraints(&self) -> &Vec<LinearCombination> {
+        &self.constraints
+    }
+
     fn multiply(
         &mut self,
         mut left: LinearCombination,
@@ -174,6 +178,10 @@ impl<'t, 'g> ConstraintSystem for RandomizingVerifier<'t, 'g> {
 
     fn num_multipliers(&self) -> usize {
         self.verifier.num_multipliers()
+    }
+
+    fn get_constraints(&self) -> &Vec<LinearCombination> {
+        self.verifier.get_constraints()
     }
 
     fn multiply(

--- a/src/r1cs/verifier.rs
+++ b/src/r1cs/verifier.rs
@@ -78,9 +78,15 @@ impl<'t, 'g> ConstraintSystem for Verifier<'t, 'g> {
     fn get_weights(&self) -> CircuitWeights {
         // Extract sparse-reduced weights from each constraint to construct the matrices
         let (w_l, w_r, w_o, w_v, c) = self
+            // It's important that this iteration is in the correct order of the constraints,
+            // otherwise we'll write the wrong index for the given constant in a constraint
             .constraints
             .iter()
-            .map(|lc| lc.extract_weights())
+            .enumerate()
+            .map(|(i, lc)| {
+                let (w_l_row, w_r_row, w_o_row, w_v_row, c_i) = lc.extract_weights();
+                (w_l_row, w_r_row, w_o_row, w_v_row, (i, c_i))
+            })
             .multiunzip();
 
         CircuitWeights {

--- a/tests/r1cs.rs
+++ b/tests/r1cs.rs
@@ -447,71 +447,78 @@ lazy_static! {
     static ref EXAMPLE_GADGET_C1: u64 = 40;
     static ref EXAMPLE_GADGET_C2: u64 = 9;
 
-    // Constraints have form: w_L * a_L + w_R * a_R + w_O * a_O = w_V * v + c
-    // Constrains (a1 + a2) * (b1 + b2) = (c1 + c2)
-    // Under the hood of the example gadget:
-
-    // v[0] = a1
-    // v[1] = a2
-    // v[2] = b1
-    // v[3] = b2
-    // v[4] = c1
-
-    // a3 = eval(v[0] + v[1])
-    // a_L[0] = a3
-    // constraints[0] = (v[0] + v[1]) - a_L[0]
-
-    // b3 = eval(v[2] + v[3])
-    // a_R[0] = b3
-    // constraints[1] = (v[2] + v[3]) - a_R[0]
-
-    // o = a3 * b3
-    // a_O[0] = o
-
-    // constraints[2] = (v[4] + c2) - a_O[0]
-
-    // Thus, matrices should be:
-
     /*
-       w_L = [           [
-           [-1],            [(0, -1)]
-           [0],    =>       []
-           [0],             []
-       ]                 ]
-    */
+    Constraints are represented by the following matrix equation:
 
-    /*
-       w_R = [           [
-           [0],             []
-           [-1],    =>      [(0, -1)]
-           [0],             []
-       ]                 ]
-    */
+    w_L * a_L + w_R * a_R + w_O * a_O = w_V * v + c
 
-    /*
-       w_O = [           [
-           [0],             []
-           [0],    =>       []
-           [-1],            [(0, -1)]
-       ]                 ]
-    */
+    where w_{i} are weight matrices, a_{i} are multiplier gate variable vectors,
+    v is the vector of high-level witness variables, and c is the vector of constants.
 
-    /*
-       Weights here are negative b/c on RHS
-       w_V = [                         [
-           [-1, -1, 0, 0, 0],             [(0, -1), (1, -1)]
-           [0, 0, -1, -1, 0],    =>       [(2, -1), (3, -1)]
-           [0, 0, 0, 0, -1],              [(4, -1)]
-       ]                               ]
-    */
+    The example gadget constrains:
 
-    /*
-       Weights here are negative b/c on RHS
-       c = [
-           0,
-           0,
-           -c2
-       ]
+    (a1 + a2) * (b1 + b2) = (c1 + c2)
+
+    Where a1, a2, b1, b2, & c1 are high-level witness variables,
+    and c2 is a public constant.
+
+    Under the hood of the example gadget, we do more or less the following:
+    ```
+        v[0] = a1
+        v[1] = a2
+        v[2] = b1
+        v[3] = b2
+        v[4] = c1
+
+        a3 = eval(v[0] + v[1])
+        a_L[0] = a3
+        constraints[0] = (v[0] + v[1]) - a_L[0]
+
+        b3 = eval(v[2] + v[3])
+        a_R[0] = b3
+        constraints[1] = (v[2] + v[3]) - a_R[0]
+
+        o = a3 * b3
+        a_O[0] = o
+
+        constraints[2] = (v[4] + c2) - a_O[0]
+    ```
+
+    Thus, matrices (& c vector) representing this gadget should be:
+    ```
+        Original matrix:                Sparse-reduced matrix:
+
+        w_L = [                         [
+            [-1],                          [(0, -1)]
+            [0],                           []
+            [0],                           []
+        ]                               ]
+
+        w_R = [                         [
+            [0],                           []
+            [-1],                          [(0, -1)]
+            [0],                           []
+        ]                               ]
+
+        w_O = [                         [
+            [0],                           []
+            [0],                           []
+            [-1],                          [(0, -1)]
+        ]                               ]
+
+        Weights here are negative b/c on RHS of matrix equation
+        w_V = [                         [
+            [-1, -1, 0, 0, 0],             [(0, -1), (1, -1)]
+            [0, 0, -1, -1, 0],             [(2, -1), (3, -1)]
+            [0, 0, 0, 0, -1],              [(4, -1)]
+        ]                               ]
+
+        Weights here are negative b/c on RHS of matrix equation
+        c = [
+            0,
+            0,                          [(2, -c2)]
+            -c2,
+        ]
     */
 
     static ref EXAMPLE_GADGET_WEIGHTS: CircuitWeights = CircuitWeights {
@@ -535,7 +542,7 @@ lazy_static! {
             SparseWeightRow(vec![(2, -Scalar::one()), (3, -Scalar::one())]),
             SparseWeightRow(vec![(4, -Scalar::one())]),
         ]),
-        c: vec![Scalar::zero(), Scalar::zero(), -Scalar::from(*EXAMPLE_GADGET_C2)]
+        c: SparseWeightRow(vec![(2, -Scalar::from(*EXAMPLE_GADGET_C2))])
     };
 }
 


### PR DESCRIPTION
This exposes functionality over the `ConstraintSystem` trait and `LinearCombination` type to extract the circuit weights in sparse-reduced form