### PR TITLE
constraint_system, linear_combination: sort lc terms by var index

### DIFF
--- a/src/r1cs/constraint_system.rs
+++ b/src/r1cs/constraint_system.rs
@@ -1,29 +1,12 @@
 //! Definition of the constraint system trait.
 
-use std::collections::HashSet;
-
 use super::{LinearCombination, R1CSError, Variable};
 use curve25519_dalek::scalar::Scalar;
 use merlin::Transcript;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, PartialEq, Eq)]
 pub struct SparseWeightRow(pub Vec<(usize, Scalar)>);
-
-impl PartialEq for SparseWeightRow {
-    fn eq(&self, other: &Self) -> bool {
-        // Because sparse constraint representation is constructed by iterating over (K, V) pairs
-        // of underlying linear combinations, order of terms in the matrix is not guaranteed.
-        // This is okay, because the matrix elements contain the index of the variable
-        // to which the given weight is applied, but requires us to have an
-        // ordering-agnostic equality relation
-        let a: HashSet<&(usize, Scalar)> = self.0.iter().collect();
-        let b: HashSet<&(usize, Scalar)> = other.0.iter().collect();
-
-        a == b
-    }
-}
-impl Eq for SparseWeightRow {}
 
 // When extracting the weights from a [`LinearCombination`], it may or may not
 // have a constant term, which is represented by an `Option<Scalar>`.

--- a/src/r1cs/linear_combination.rs
+++ b/src/r1cs/linear_combination.rs
@@ -2,6 +2,7 @@
 
 use core::ops::{AddAssign, MulAssign, SubAssign};
 use curve25519_dalek::scalar::Scalar;
+use itertools::Itertools;
 use std::collections::HashMap;
 use std::iter::FromIterator;
 use std::ops::{Add, Mul, Neg, Sub};
@@ -153,9 +154,20 @@ impl LinearCombination {
         let mut w_v_row = SparseWeightRow(Vec::new());
         let mut c = None;
 
+        // Iterating over the LC terms here has non-deterministic order.
+        // We want terms to be ordered by variable index, so we sort them
         self.terms
             .iter()
             .filter(|(_, &coeff)| coeff != Scalar::zero())
+            .sorted_by_key(|(&var, _)| match var {
+                Variable::MultiplierLeft(i) => i,
+                Variable::MultiplierRight(i) => i,
+                Variable::MultiplierOutput(i) => i,
+                Variable::Committed(i) => i,
+                // Sorting for constant variables is not necessary
+                Variable::One() => usize::MAX,
+                Variable::Zero() => usize::MAX,
+            })
             .for_each(|(&var, &coeff)| match var {
                 Variable::MultiplierLeft(i) => {
                     w_l_row.0.push((i, coeff));


### PR DESCRIPTION
Previously, we would allow non-deterministic ordering of terms in a linear constraint, i.e. non-deterministic ordering of rows in circuit weight matrices (and we adapted our notion of row equality to be ordering agnostic).

Having deterministic ordering by increasing variable index makes implementation significantly simpler and more efficient contract-side, so this PR introduces that.