### PR TITLE
transcript, generators: match Cairo transcript & generator operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The following example shows how to create and verify a 32-bit rangeproof.
 # use curve25519_dalek::scalar::Scalar;
 #
 # extern crate merlin;
-# use merlin::Transcript;
+# use merlin::HashChainTranscript as Transcript;
 #
 # extern crate bulletproofs;
 # use bulletproofs::{BulletproofGens, PedersenGens, RangeProof};

--- a/benches/r1cs.rs
+++ b/benches/r1cs.rs
@@ -13,7 +13,7 @@ use criterion::Criterion;
 // someone wants to figure a way to use #[path] attributes or
 // something to avoid the duplication.
 
-use merlin::Transcript;
+use merlin::HashChainTranscript as Transcript;
 use mpc_bulletproof::r1cs::*;
 use mpc_bulletproof::{BulletproofGens, PedersenGens};
 use mpc_stark::algebra::scalar::Scalar;

--- a/docs/r1cs-docs-example.md
+++ b/docs/r1cs-docs-example.md
@@ -66,7 +66,7 @@ use bulletproofs::r1cs::*;
 use bulletproofs::{BulletproofGens, PedersenGens};
 use curve25519_dalek::ristretto::CompressedRistretto;
 use curve25519_dalek::scalar::Scalar;
-use merlin::Transcript;
+use merlin::HashChainTranscript as Transcript;
 use rand::thread_rng;
 
 // Shuffle gadget (documented in markdown file)
@@ -147,7 +147,7 @@ For simplicity, in this example the `prove` function does not take a list of bli
 # use bulletproofs::{BulletproofGens, PedersenGens};
 # use curve25519_dalek::ristretto::CompressedRistretto;
 # use curve25519_dalek::scalar::Scalar;
-# use merlin::Transcript;
+# use merlin::HashChainTranscript as Transcript;
 # use rand::thread_rng;
 # 
 # // Shuffle gadget (documented in markdown file)
@@ -254,7 +254,7 @@ The verifier receives a proof, and a list of committed inputs and outputs, from 
 # use bulletproofs::{BulletproofGens, PedersenGens};
 # use curve25519_dalek::ristretto::CompressedRistretto;
 # use curve25519_dalek::scalar::Scalar;
-# use merlin::Transcript;
+# use merlin::HashChainTranscript as Transcript;
 # use rand::thread_rng;
 # 
 # // Shuffle gadget (documented in markdown file)
@@ -394,7 +394,7 @@ Because only the prover knows the scalar values of the inputs and outputs, and t
 # use bulletproofs::{BulletproofGens, PedersenGens};
 # use curve25519_dalek::ristretto::CompressedRistretto;
 # use curve25519_dalek::scalar::Scalar;
-# use merlin::Transcript;
+# use merlin::HashChainTranscript as Transcript;
 # use rand::thread_rng;
 # 
 # // Shuffle gadget (documented in markdown file)

--- a/integration/mpc_prover.rs
+++ b/integration/mpc_prover.rs
@@ -14,7 +14,7 @@ use mpc_bulletproof::{
 };
 
 use itertools::Itertools;
-use merlin::Transcript;
+use merlin::HashChainTranscript as Transcript;
 use mpc_stark::{
     algebra::{
         authenticated_stark_point::AuthenticatedStarkPointOpenResult, scalar::Scalar,

--- a/src/generators.rs
+++ b/src/generators.rs
@@ -16,6 +16,8 @@ use mpc_stark::algebra::stark_curve::StarkPoint;
 use mpc_stark::algebra::stark_curve::StarkPointResult;
 use mpc_stark::algebra::stark_curve::STARK_POINT_BYTES;
 
+use crate::util::hash_to_scalar;
+
 /// Represents a pair of base points for Pedersen commitments.
 ///
 /// The Bulletproofs implementation and API is designed to support
@@ -118,7 +120,7 @@ impl Iterator for GeneratorsChain {
         // multiply by the generator point.
         // Examples of other such hash-to-curve schemes that do not hide the scalar multiple:
         // https://eprint.iacr.org/2009/226.pdf and https://link.springer.com/chapter/10.1007/978-3-642-14623-7_13
-        let scalar = Scalar::from_uniform_bytes(low_u256);
+        let scalar = hash_to_scalar(low_u256);
         Some(scalar * StarkPoint::generator())
     }
 

--- a/src/inner_product_proof.rs
+++ b/src/inner_product_proof.rs
@@ -9,7 +9,7 @@ use mpc_stark::algebra::scalar::{Scalar, SCALAR_BYTES};
 use mpc_stark::algebra::stark_curve::{StarkPoint, STARK_POINT_BYTES};
 
 use core::iter;
-use merlin::Transcript;
+use merlin::HashChainTranscript as Transcript;
 
 use crate::errors::ProofError;
 use crate::transcript::TranscriptProtocol;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ mod inner_product_proof;
 #[cfg(feature = "integration_test")]
 pub use inner_product_proof::*;
 // mod range_proof;
-mod transcript;
+pub mod transcript;
 
 pub use crate::errors::ProofError;
 pub use crate::generators::{BulletproofGens, BulletproofGensShare, PedersenGens};

--- a/src/r1cs/constraint_system.rs
+++ b/src/r1cs/constraint_system.rs
@@ -3,7 +3,7 @@
 use std::collections::HashSet;
 
 use super::{LinearCombination, R1CSError, Variable};
-use merlin::Transcript;
+use merlin::HashChainTranscript as Transcript;
 use mpc_stark::algebra::scalar::Scalar;
 use serde::{Deserialize, Serialize};
 

--- a/src/r1cs/linear_combination.rs
+++ b/src/r1cs/linear_combination.rs
@@ -296,7 +296,7 @@ impl<S: Into<Scalar>> Mul<S> for LinearCombination {
 
 #[cfg(test)]
 mod tests {
-    use merlin::Transcript;
+    use merlin::HashChainTranscript as Transcript;
     use mpc_stark::algebra::scalar::Scalar;
 
     use crate::{

--- a/src/r1cs/prover.rs
+++ b/src/r1cs/prover.rs
@@ -433,17 +433,15 @@ impl<'t, 'g> Prover<'t, 'g> {
         // protect the v's in the commitments), we don't gain much by
         // committing the v's as well as the v_blinding's.
         let mut rng = {
-            // let mut builder = self.transcript.build_rng();
+            let mut builder = self.transcript.build_rng();
 
-            // // Commit the blinding factors for the input wires
-            // for v_b in &self.v_blinding {
-            //     builder = builder.rekey_with_witness_bytes(b"v_blinding", &v_b.to_bytes_be());
-            // }
+            // Commit the blinding factors for the input wires
+            for v_b in &self.v_blinding {
+                builder = builder.rekey_with_witness_bytes(b"v_blinding", &v_b.to_bytes_be());
+            }
 
-            // use rand::thread_rng;
-            // builder.finalize(&mut thread_rng())
             use rand::thread_rng;
-            thread_rng()
+            builder.finalize(&mut thread_rng())
         };
 
         // Commit to the first-phase low-level witness variables.

--- a/src/r1cs/prover.rs
+++ b/src/r1cs/prover.rs
@@ -1,7 +1,7 @@
 #![allow(non_snake_case)]
 
 use itertools::Itertools;
-use merlin::Transcript;
+use merlin::HashChainTranscript as Transcript;
 use mpc_stark::algebra::scalar::Scalar;
 use mpc_stark::algebra::stark_curve::StarkPoint;
 
@@ -433,15 +433,17 @@ impl<'t, 'g> Prover<'t, 'g> {
         // protect the v's in the commitments), we don't gain much by
         // committing the v's as well as the v_blinding's.
         let mut rng = {
-            let mut builder = self.transcript.build_rng();
+            // let mut builder = self.transcript.build_rng();
 
-            // Commit the blinding factors for the input wires
-            for v_b in &self.v_blinding {
-                builder = builder.rekey_with_witness_bytes(b"v_blinding", &v_b.to_bytes_be());
-            }
+            // // Commit the blinding factors for the input wires
+            // for v_b in &self.v_blinding {
+            //     builder = builder.rekey_with_witness_bytes(b"v_blinding", &v_b.to_bytes_be());
+            // }
 
+            // use rand::thread_rng;
+            // builder.finalize(&mut thread_rng())
             use rand::thread_rng;
-            builder.finalize(&mut thread_rng())
+            thread_rng()
         };
 
         // Commit to the first-phase low-level witness variables.

--- a/src/r1cs/verifier.rs
+++ b/src/r1cs/verifier.rs
@@ -1,7 +1,7 @@
 #![allow(non_snake_case)]
 
 use itertools::Itertools;
-use merlin::Transcript;
+use merlin::HashChainTranscript as Transcript;
 use mpc_stark::algebra::scalar::Scalar;
 use mpc_stark::algebra::stark_curve::StarkPoint;
 
@@ -503,9 +503,9 @@ impl<'t, 'g> Verifier<'t, 'g> {
         // Create a `TranscriptRng` from the transcript. The verifier
         // has no witness data to commit, so this just mixes external
         // randomness into the existing transcript.
-        use rand::thread_rng;
-        let mut rng = self.transcript.build_rng().finalize(&mut thread_rng());
-        let r = Scalar::random(&mut rng);
+        // use rand::thread_rng;
+        // let mut rng = self.transcript.build_rng().finalize(&mut thread_rng());
+        let r = self.transcript.challenge_scalar(b"r");
 
         let xx = x * x;
         let rxx = r * xx;

--- a/src/r1cs/verifier.rs
+++ b/src/r1cs/verifier.rs
@@ -503,8 +503,6 @@ impl<'t, 'g> Verifier<'t, 'g> {
         // Create a `TranscriptRng` from the transcript. The verifier
         // has no witness data to commit, so this just mixes external
         // randomness into the existing transcript.
-        // use rand::thread_rng;
-        // let mut rng = self.transcript.build_rng().finalize(&mut thread_rng());
         let r = self.transcript.challenge_scalar(b"r");
 
         let xx = x * x;

--- a/src/r1cs_mpc/mpc_prover.rs
+++ b/src/r1cs_mpc/mpc_prover.rs
@@ -9,7 +9,7 @@ use crate::{
     util, BulletproofGens, PedersenGens,
 };
 use futures::future::join_all;
-use merlin::Transcript;
+use merlin::HashChainTranscript as Transcript;
 use mpc_stark::{
     algebra::{
         authenticated_scalar::AuthenticatedScalarResult,

--- a/tests/r1cs.rs
+++ b/tests/r1cs.rs
@@ -6,7 +6,7 @@ extern crate mpc_bulletproof;
 extern crate rand;
 
 use lazy_static::lazy_static;
-use merlin::Transcript;
+use merlin::HashChainTranscript as Transcript;
 use mpc_bulletproof::r1cs::*;
 use mpc_bulletproof::{BulletproofGens, PedersenGens};
 use mpc_stark::algebra::scalar::Scalar;


### PR DESCRIPTION
This PR substitutes the Merlin transcript for our own `HashChainTranscript` introduced in https://github.com/renegade-fi/merlin/pull/2, and additionally changes the generator sampling process to match that which is used in Cairo (no longer using SWU map, simply converting a hash to a scalar and multiplying by the STARK generator point).

This won't build until https://github.com/renegade-fi/merlin/pull/2 and https://github.com/renegade-fi/mpc-stark/pull/2 are merged.