### PR TITLE
transcript: Fix MPC and native consistency issues

### DIFF
--- a/integration/transcript.rs
+++ b/integration/transcript.rs
@@ -1,7 +1,7 @@
 //! Groups tests for the synchronized MPC transcript
 
 use itertools::Itertools;
-use merlin::Transcript;
+use merlin::HashChainTranscript;
 use mpc_bulletproof::MpcTranscript;
 use mpc_stark::{algebra::scalar::Scalar, random_point, PARTY0, PARTY1};
 use rand::thread_rng;
@@ -37,7 +37,7 @@ fn test_add_scalars(test_args: &IntegrationTestArgs) -> Result<(), String> {
         .map(|s| s.value)
         .collect_vec();
 
-    let mut transcript = MpcTranscript::new(Transcript::new(b"test"), fabric.clone());
+    let mut transcript = MpcTranscript::new(HashChainTranscript::new(b"test"), fabric.clone());
     for scalar in opened_scalars.into_iter() {
         transcript.append_scalar(b"Scalar", &scalar);
     }
@@ -77,7 +77,7 @@ fn test_add_points(test_args: &IntegrationTestArgs) -> Result<(), String> {
         .map(|p| p.value)
         .collect_vec();
 
-    let mut transcript = MpcTranscript::new(Transcript::new(b"test"), fabric.clone());
+    let mut transcript = MpcTranscript::new(HashChainTranscript::new(b"test"), fabric.clone());
     for point in opened_points.into_iter() {
         transcript.append_point(b"Point", &point);
     }

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -155,8 +155,7 @@ impl MpcTranscript {
         self.fabric
             .new_gate_op::<_, Scalar>(vec![self.latest_op_id], move |_args| {
                 let mut locked_transcript = transcript_ref.lock().expect(ERR_LOCK_POISONED);
-                locked_transcript.append_message(b"dom-sep", b"ipp v1");
-                locked_transcript.append_u64(b"n", n);
+                locked_transcript.innerproduct_domain_sep(n);
 
                 ResultValue::Scalar(Scalar::zero())
             });
@@ -168,7 +167,7 @@ impl MpcTranscript {
         self.fabric
             .new_gate_op::<_, Scalar>(vec![self.latest_op_id], move |_args| {
                 let mut locked_transcript = transcript_ref.lock().expect(ERR_LOCK_POISONED);
-                locked_transcript.append_message(b"dom-sep", b"r1cs v1");
+                locked_transcript.r1cs_domain_sep();
 
                 ResultValue::Scalar(Scalar::zero())
             });
@@ -180,7 +179,7 @@ impl MpcTranscript {
         self.fabric
             .new_gate_op::<_, Scalar>(vec![self.latest_op_id], move |_args| {
                 let mut locked_transcript = transcript_ref.lock().expect(ERR_LOCK_POISONED);
-                locked_transcript.append_message(b"dom-sep", b"r1cs-1phase");
+                locked_transcript.r1cs_1phase_domain_sep();
 
                 ResultValue::Scalar(Scalar::zero())
             });


### PR DESCRIPTION
### Purpose
This PR fixes an issue with the MPC transcript in which labels were not padded the way they are in the native `HashChainTranscript`. This leads the transcripts to be out of sync, causing valid proofs to fail verification.

This PR fixes this by calling out to the underlying `HashChainTranscript` implementation directly.

### Testing
- Unit and integration tests pass