### PR TITLE
r1cs-mpc: mpc-prover: Remove lifetimes and force prover to be `Send`

### DIFF
--- a/src/r1cs_mpc/mpc_constraint_system.rs
+++ b/src/r1cs_mpc/mpc_constraint_system.rs
@@ -21,7 +21,7 @@ use super::{
 /// verifier, gadgets for the constraint system should be written
 /// using the `ConstraintSystem` trait, so that the prover and
 /// verifier share the logic for specifying constraints.
-pub trait MpcConstraintSystem<'a> {
+pub trait MpcConstraintSystem {
     /// Leases the proof transcript to the user, so they can
     /// add extra data to which the proof must be bound, but which
     /// is not available before creation of the constraint system.
@@ -94,9 +94,9 @@ pub trait MpcConstraintSystem<'a> {
 /// while gadgets that need randomization should use trait bound `CS: RandomizedConstraintSystem`.
 /// Gadgets generally _should not_ use this trait as a bound on the CS argument: it should be used
 /// by the higher-order protocol that composes gadgets together.
-pub trait MpcRandomizableConstraintSystem<'a>: MpcConstraintSystem<'a> {
+pub trait MpcRandomizableConstraintSystem: MpcConstraintSystem {
     /// Represents a concrete type for the CS in a randomization phase.
-    type RandomizedCS: MpcRandomizedConstraintSystem<'a>;
+    type RandomizedCS: MpcRandomizedConstraintSystem;
 
     /// Specify additional variables and constraints randomized using a challenge scalar
     /// bound to the assignments of the non-randomized variables.
@@ -119,7 +119,7 @@ pub trait MpcRandomizableConstraintSystem<'a>: MpcConstraintSystem<'a> {
     /// ```
     fn specify_randomized_constraints<F>(&mut self, callback: F) -> Result<(), R1CSError>
     where
-        F: 'a + Fn(&mut Self::RandomizedCS) -> Result<(), R1CSError>;
+        F: 'static + Send + Fn(&mut Self::RandomizedCS) -> Result<(), R1CSError>;
 }
 
 /// Represents a constraint system in the second phase:
@@ -127,7 +127,7 @@ pub trait MpcRandomizableConstraintSystem<'a>: MpcConstraintSystem<'a> {
 ///
 /// Note: this trait also includes `ConstraintSystem` trait
 /// in order to allow composition of gadgets: e.g. a shuffle gadget can be used in both phases.
-pub trait MpcRandomizedConstraintSystem<'a>: MpcConstraintSystem<'a> {
+pub trait MpcRandomizedConstraintSystem: MpcConstraintSystem {
     /// Generates a challenge scalar.
     ///
     /// ### Usage

--- a/src/r1cs_mpc/mpc_prover.rs
+++ b/src/r1cs_mpc/mpc_prover.rs
@@ -56,11 +56,11 @@ use super::{
 /// challenges from the protocol transcript that precedes them. These constraints are encoded in the
 /// `deferred_constraints` field.
 #[allow(dead_code, non_snake_case)]
-pub struct MpcProver<'a, 't, 'g> {
+pub struct MpcProver {
     /// The protocol transcript, used for constructing Fiat-Shamir challenges
     transcript: MpcTranscript,
     /// Generators used for Pedersen commitments
-    pc_gens: &'g PedersenGens,
+    pc_gens: PedersenGens,
     /// Teh constraints accumulated so far.
     constraints: Vec<MpcLinearCombination>,
     /// Stores assignments to the "left" of multiplication gates.
@@ -82,7 +82,7 @@ pub struct MpcProver<'a, 't, 'g> {
     /// when non-randomized variables are committed.
     #[allow(clippy::type_complexity)]
     deferred_constraints:
-        Vec<Box<dyn Fn(&mut RandomizingMpcProver<'a, 't, 'g>) -> Result<(), R1CSError> + 'a>>,
+        Vec<Box<dyn Send + FnOnce(&mut RandomizingMpcProver) -> Result<(), R1CSError>>>,
     /// The underlying MPC fabric
     fabric: MpcFabric,
 }
@@ -91,17 +91,17 @@ pub struct MpcProver<'a, 't, 'g> {
 ///
 /// In this phase constraints may be built using challenge scalars derived from the
 /// protocol transcript so far.
-pub struct RandomizingMpcProver<'a, 't, 'g> {
-    prover: MpcProver<'a, 't, 'g>,
+pub struct RandomizingMpcProver {
+    prover: MpcProver,
 }
 
-impl<'a, 't, 'g> MpcProver<'a, 't, 'g> {
+impl MpcProver {
     /// Create a new MpcProver with a custom network
     pub fn new_with_network<S: 'static + SharedValueSource>(
         network: QuicTwoPartyNet,
         beaver_source: S,
         transcript: Transcript,
-        pc_gens: &'g PedersenGens,
+        pc_gens: PedersenGens,
     ) -> Self {
         // Build a fabric and transcript
         let fabric = MpcFabric::new(network, beaver_source);
@@ -130,7 +130,7 @@ impl<'a, 't, 'g> MpcProver<'a, 't, 'g> {
     pub fn new_with_fabric(
         fabric: MpcFabric,
         transcript: Transcript,
-        pc_gens: &'g PedersenGens,
+        pc_gens: PedersenGens,
     ) -> Self {
         let mut transcript = MpcTranscript::new(transcript, fabric.clone());
         transcript.r1cs_domain_sep();
@@ -173,7 +173,7 @@ impl<'a, 't, 'g> MpcProver<'a, 't, 'g> {
     }
 }
 
-impl<'a, 't, 'g> MpcConstraintSystem<'a> for MpcProver<'a, 't, 'g> {
+impl MpcConstraintSystem for MpcProver {
     /// Lease the transcript to the caller
     fn transcript(&mut self) -> &mut MpcTranscript {
         self.transcript.borrow_mut()
@@ -295,19 +295,19 @@ impl<'a, 't, 'g> MpcConstraintSystem<'a> for MpcProver<'a, 't, 'g> {
     }
 }
 
-impl<'a, 't, 'g> MpcRandomizableConstraintSystem<'a> for MpcProver<'a, 't, 'g> {
-    type RandomizedCS = RandomizingMpcProver<'a, 't, 'g>;
+impl MpcRandomizableConstraintSystem for MpcProver {
+    type RandomizedCS = RandomizingMpcProver;
 
     fn specify_randomized_constraints<F>(&mut self, callback: F) -> Result<(), R1CSError>
     where
-        F: 'a + Fn(&mut Self::RandomizedCS) -> Result<(), R1CSError>,
+        F: 'static + Send + FnOnce(&mut Self::RandomizedCS) -> Result<(), R1CSError>,
     {
         self.deferred_constraints.push(Box::new(callback));
         Ok(())
     }
 }
 
-impl<'a, 't, 'g> MpcConstraintSystem<'a> for RandomizingMpcProver<'a, 't, 'g> {
+impl MpcConstraintSystem for RandomizingMpcProver {
     fn transcript(&mut self) -> &mut MpcTranscript {
         self.prover.transcript()
     }
@@ -347,13 +347,13 @@ impl<'a, 't, 'g> MpcConstraintSystem<'a> for RandomizingMpcProver<'a, 't, 'g> {
     }
 }
 
-impl<'a, 't, 'g> MpcRandomizedConstraintSystem<'a> for RandomizingMpcProver<'a, 't, 'g> {
+impl MpcRandomizedConstraintSystem for RandomizingMpcProver {
     fn challenge_scalar(&mut self, label: &'static [u8]) -> ScalarResult {
         self.prover.transcript.challenge_scalar(label)
     }
 }
 
-impl<'a, 't, 'g> MpcProver<'a, 't, 'g> {
+impl MpcProver {
     /// From a privately held input value, secret share the value and commit to it
     ///
     /// The result is a variable allocated both in the MPC network and in the
@@ -989,5 +989,20 @@ impl<'a, 't, 'g> MpcProver<'a, 't, 'g> {
             e_blinding: e_blinding_open,
             ipp_proof: ipp,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MpcProver;
+
+    /// This will fail to compile if T is not Send
+    fn assert_send<T: Send>() {}
+
+    /// Assert that the prover is `Send`, we require this because much of the
+    /// proof generation happens async
+    #[test]
+    fn test_prover_is_send() {
+        assert_send::<MpcProver>()
     }
 }


### PR DESCRIPTION
### Purpose
This PR forces the `MpcProver` object to be `Send` now that we run MPCs in a more async-friendly manner. This involves:
- Forcing second phase callbacks to be `Send`
- Removing stored referencing, forcing the prover to take ownership of all its fields. This also allows us to clean up the interfaces by removing messy lifetime parameters

### Testing
- All unit and integration tests pass