### PR TITLE
proof, inner_product_proof, verifier: expose needed fields & methods

### DIFF
--- a/src/inner_product_proof.rs
+++ b/src/inner_product_proof.rs
@@ -16,10 +16,10 @@ use crate::transcript::TranscriptProtocol;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct InnerProductProof {
-    pub(crate) L_vec: Vec<StarkPoint>,
-    pub(crate) R_vec: Vec<StarkPoint>,
-    pub(crate) a: Scalar,
-    pub(crate) b: Scalar,
+    pub L_vec: Vec<StarkPoint>,
+    pub R_vec: Vec<StarkPoint>,
+    pub a: Scalar,
+    pub b: Scalar,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -197,7 +197,7 @@ impl InnerProductProof {
     /// in a parent protocol. See [inner product protocol notes](index.html#verification-equation) for details.
     /// The verifier must provide the input length \\(n\\) explicitly to avoid unbounded allocation within the inner product proof.
     #[allow(clippy::type_complexity)]
-    pub(crate) fn verification_scalars(
+    pub fn verification_scalars(
         &self,
         n: usize,
         transcript: &mut Transcript,

--- a/src/r1cs/proof.rs
+++ b/src/r1cs/proof.rs
@@ -34,36 +34,36 @@ const TWO_PHASE_COMMITMENTS: u8 = 1;
 #[allow(non_snake_case)]
 pub struct R1CSProof {
     /// Commitment to the values of input wires in the first phase.
-    pub(crate) A_I1: StarkPoint,
+    pub A_I1: StarkPoint,
     /// Commitment to the values of output wires in the first phase.
-    pub(crate) A_O1: StarkPoint,
+    pub A_O1: StarkPoint,
     /// Commitment to the blinding factors in the first phase.
-    pub(crate) S1: StarkPoint,
+    pub S1: StarkPoint,
     /// Commitment to the values of input wires in the second phase.
-    pub(crate) A_I2: StarkPoint,
+    pub A_I2: StarkPoint,
     /// Commitment to the values of output wires in the second phase.
-    pub(crate) A_O2: StarkPoint,
+    pub A_O2: StarkPoint,
     /// Commitment to the blinding factors in the second phase.
-    pub(crate) S2: StarkPoint,
+    pub S2: StarkPoint,
     /// Commitment to the \\(t_1\\) coefficient of \\( t(x) \\)
-    pub(crate) T_1: StarkPoint,
+    pub T_1: StarkPoint,
     /// Commitment to the \\(t_3\\) coefficient of \\( t(x) \\)
-    pub(crate) T_3: StarkPoint,
+    pub T_3: StarkPoint,
     /// Commitment to the \\(t_4\\) coefficient of \\( t(x) \\)
-    pub(crate) T_4: StarkPoint,
+    pub T_4: StarkPoint,
     /// Commitment to the \\(t_5\\) coefficient of \\( t(x) \\)
-    pub(crate) T_5: StarkPoint,
+    pub T_5: StarkPoint,
     /// Commitment to the \\(t_6\\) coefficient of \\( t(x) \\)
-    pub(crate) T_6: StarkPoint,
+    pub T_6: StarkPoint,
     /// Evaluation of the polynomial \\(t(x)\\) at the challenge point \\(x\\)
-    pub(crate) t_x: Scalar,
+    pub t_x: Scalar,
     /// Blinding factor for the synthetic commitment to \\( t(x) \\)
-    pub(crate) t_x_blinding: Scalar,
+    pub t_x_blinding: Scalar,
     /// Blinding factor for the synthetic commitment to the
     /// inner-product arguments
-    pub(crate) e_blinding: Scalar,
+    pub e_blinding: Scalar,
     /// Proof data for the inner-product argument.
-    pub(crate) ipp_proof: InnerProductProof,
+    pub ipp_proof: InnerProductProof,
 }
 
 impl R1CSProof {

--- a/src/r1cs/verifier.rs
+++ b/src/r1cs/verifier.rs
@@ -320,7 +320,7 @@ impl<'t, 'g> Verifier<'t, 'g> {
     /// This has the same logic as `ProverCS::flattened_constraints()`
     /// but also computes the constant terms (which the prover skips
     /// because they're not needed to construct the proof).
-    fn flattened_constraints(
+    pub fn flattened_constraints(
         &mut self,
         z: &Scalar,
     ) -> (Vec<Scalar>, Vec<Scalar>, Vec<Scalar>, Vec<Scalar>, Scalar) {


### PR DESCRIPTION
This PR reintroduces the changes from #6 & #7 that seemed to be swallowed by a rebase, and exposes the `verification_scalars` & `flattened_constraints` methods which are used for integration testing.