### PR TITLE
inner-product-proof: Compute protocol round reduction/folding in parallel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ description = "A pure-Rust implementation of collaboratively proved Bulletproofs
 edition = "2021"
 
 [dependencies]
-ark-ec = "0.4"
 ark-ff = "0.4"
 ark-serialize = "0.4"
 futures = "0.3"
@@ -24,6 +23,7 @@ sha3 = { version = "0.8", default-features = false }
 digest = { version = "0.8", default-features = false }
 rand_core = { version = "0.5", default-features = false, features = ["alloc"] }
 rand = { version = "0.8", default-features = false, optional = true }
+rayon = "1"
 byteorder = { version = "1", default-features = false }
 num-bigint = "0.4"
 itertools = "0.10"
@@ -32,6 +32,7 @@ serde_derive = { version = "1", default-features = false }
 thiserror = { version = "1", optional = true }
 tokio = { version = "1.12", features = ["macros", "rt-multi-thread"] }
 merlin = { git = "https://github.com/renegade-fi/merlin" }
+unzip-n = "0.1"
 
 [dev-dependencies]
 async-std = "1.12"
@@ -56,19 +57,25 @@ integration_test = []
 
 [[test]]
 name = "r1cs"
-required_features = ["multiprover"]
 
 [[test]]
 name = "integration"
 path = "integration/main.rs"
 harness = false
-required_features = ["integration_test", "multiprover"]
 
 [[bench]]
 name = "generators"
 harness = false
 
 [[bench]]
-name = "r1cs"
+name = "shuffle"
 harness = false
 required-features = ["multiprover"]
+
+[[bench]]
+name = "r1cs"
+harness = false
+
+[[bench]]
+name = "inner_product"
+harness = false

--- a/benches/inner_product.rs
+++ b/benches/inner_product.rs
@@ -1,0 +1,83 @@
+//! Benchmarks for the inner product proof
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use itertools::Itertools;
+use merlin::HashChainTranscript;
+use mpc_bulletproof::InnerProductProof;
+use mpc_stark::{
+    algebra::{scalar::Scalar, stark_curve::StarkPoint},
+    random_point,
+};
+use rand::thread_rng;
+
+/// The max number of constraints to benchmark
+const MAX_CONSTRAINTS_LN: usize = 16; // 2^10 = 1024
+
+// -----------
+// | Helpers |
+// -----------
+
+/// Generate a set of random scalars
+fn random_scalars(n: usize) -> Vec<Scalar> {
+    (0..n)
+        .map(|_| Scalar::random(&mut thread_rng()))
+        .collect_vec()
+}
+
+/// Generate a set of random points
+fn random_points(n: usize) -> Vec<StarkPoint> {
+    (0..n).map(|_| random_point()).collect_vec()
+}
+
+/// Benchmark a prover with a given number of constraints
+#[allow(non_snake_case)]
+fn bench_prover_with_size(n_elems: usize, c: &mut Criterion) {
+    assert!(n_elems.is_power_of_two());
+
+    let mut group = c.benchmark_group("inner_product");
+    let benchmark_id = BenchmarkId::new("ipp-prover", n_elems);
+    group.bench_function(benchmark_id, |b| {
+        // Create the IPP inputs
+        let mut transcript = HashChainTranscript::new(b"test");
+        let Q = random_point();
+        let G_factors = random_scalars(n_elems);
+        let H_factors = random_scalars(n_elems);
+        let G_vec = random_points(n_elems);
+        let H_vec = random_points(n_elems);
+        let a_vec = random_scalars(n_elems);
+        let b_vec = random_scalars(n_elems);
+
+        b.iter(|| {
+            let _proof = InnerProductProof::create(
+                &mut transcript,
+                &Q,
+                &G_factors,
+                &H_factors,
+                G_vec.clone(),
+                H_vec.clone(),
+                a_vec.clone(),
+                b_vec.clone(),
+            );
+            black_box(_proof);
+        })
+    });
+}
+
+// --------------
+// | Benchmarks |
+// --------------
+
+/// Benchmark the prover with a range of constraint sizes
+fn bench_prover(c: &mut Criterion) {
+    // Benchmark a range of constraint sizes
+    for i in (1..=MAX_CONSTRAINTS_LN).map(|i| 1 << i) {
+        bench_prover_with_size(i, c);
+    }
+}
+
+criterion_group!(
+    name = inner_product;
+    config = Criterion::default().sample_size(10);
+    targets = bench_prover,
+);
+criterion_main!(inner_product);

--- a/benches/shuffle.rs
+++ b/benches/shuffle.rs
@@ -1,0 +1,247 @@
+#![allow(non_snake_case)]
+
+#[macro_use]
+extern crate criterion;
+use criterion::Criterion;
+
+// Code below copied from ../tests/r1cs.rs
+//
+// Ideally we wouldn't duplicate it, but AFAIK criterion requires a
+// seperate benchmark harness, while the test code uses a different
+// test harness, so I (hdevalence) just copied the code over.  It
+// should not be edited here.  In the future it would be good if
+// someone wants to figure a way to use #[path] attributes or
+// something to avoid the duplication.
+
+use merlin::HashChainTranscript as Transcript;
+use mpc_bulletproof::r1cs::*;
+use mpc_bulletproof::{BulletproofGens, PedersenGens};
+use mpc_stark::algebra::scalar::Scalar;
+use mpc_stark::algebra::stark_curve::StarkPoint;
+use rand::seq::SliceRandom;
+use rand::{thread_rng, Rng};
+
+// Shuffle gadget (documented in markdown file)
+
+/// A proof-of-shuffle.
+struct ShuffleProof(R1CSProof);
+
+impl ShuffleProof {
+    fn gadget<CS: RandomizableConstraintSystem>(
+        cs: &mut CS,
+        x: Vec<Variable>,
+        y: Vec<Variable>,
+    ) -> Result<(), R1CSError> {
+        assert_eq!(x.len(), y.len());
+        let k = x.len();
+
+        if k == 1 {
+            cs.constrain(y[0] - x[0]);
+            return Ok(());
+        }
+
+        cs.specify_randomized_constraints(move |cs| {
+            let z = cs.challenge_scalar(b"shuffle challenge");
+
+            // Make last x multiplier for i = k-1 and k-2
+            let (_, _, last_mulx_out) = cs.multiply(x[k - 1] - z, x[k - 2] - z);
+
+            // Make multipliers for x from i == [0, k-3]
+            let first_mulx_out = (0..k - 2).rev().fold(last_mulx_out, |prev_out, i| {
+                let (_, _, o) = cs.multiply(prev_out.into(), x[i] - z);
+                o
+            });
+
+            // Make last y multiplier for i = k-1 and k-2
+            let (_, _, last_muly_out) = cs.multiply(y[k - 1] - z, y[k - 2] - z);
+
+            // Make multipliers for y from i == [0, k-3]
+            let first_muly_out = (0..k - 2).rev().fold(last_muly_out, |prev_out, i| {
+                let (_, _, o) = cs.multiply(prev_out.into(), y[i] - z);
+                o
+            });
+
+            // Constrain last x mul output and last y mul output to be equal
+            cs.constrain(first_mulx_out - first_muly_out);
+
+            Ok(())
+        })
+    }
+}
+
+impl ShuffleProof {
+    /// Attempt to construct a proof that `output` is a permutation of `input`.
+    ///
+    /// Returns a tuple `(proof, input_commitments || output_commitments)`.
+    pub fn prove(
+        pc_gens: &PedersenGens,
+        bp_gens: &BulletproofGens,
+        transcript: &mut Transcript,
+        input: &[Scalar],
+        output: &[Scalar],
+    ) -> Result<(ShuffleProof, Vec<StarkPoint>, Vec<StarkPoint>), R1CSError> {
+        // Apply a domain separator with the shuffle parameters to the transcript
+        // XXX should this be part of the gadget?
+        let mut rng = thread_rng();
+        let k = input.len();
+        transcript.append_message(b"dom-sep", b"ShuffleProof");
+        transcript.append_u64(b"k", k as u64);
+
+        let mut prover = Prover::new(pc_gens, transcript);
+
+        let (input_commitments, input_vars): (Vec<_>, Vec<_>) = input
+            .iter()
+            .map(|v| prover.commit(*v, Scalar::random(&mut rng)))
+            .unzip();
+
+        let (output_commitments, output_vars): (Vec<_>, Vec<_>) = output
+            .iter()
+            .map(|v| prover.commit(*v, Scalar::random(&mut rng)))
+            .unzip();
+
+        ShuffleProof::gadget(&mut prover, input_vars, output_vars)?;
+
+        let proof = prover.prove(bp_gens)?;
+
+        Ok((ShuffleProof(proof), input_commitments, output_commitments))
+    }
+}
+
+impl ShuffleProof {
+    /// Attempt to verify a `ShuffleProof`.
+    pub fn verify(
+        &self,
+        pc_gens: &PedersenGens,
+        bp_gens: &BulletproofGens,
+        transcript: &mut Transcript,
+        input_commitments: &[StarkPoint],
+        output_commitments: &[StarkPoint],
+    ) -> Result<(), R1CSError> {
+        // Apply a domain separator with the shuffle parameters to the transcript
+        // XXX should this be part of the gadget?
+        let k = input_commitments.len();
+        transcript.append_message(b"dom-sep", b"ShuffleProof");
+        transcript.append_u64(b"k", k as u64);
+
+        let mut verifier = Verifier::new(pc_gens, transcript);
+
+        let input_vars: Vec<_> = input_commitments
+            .iter()
+            .map(|V| verifier.commit(*V))
+            .collect();
+
+        let output_vars: Vec<_> = output_commitments
+            .iter()
+            .map(|V| verifier.commit(*V))
+            .collect();
+
+        ShuffleProof::gadget(&mut verifier, input_vars, output_vars)?;
+
+        verifier.verify(&self.0, bp_gens)
+    }
+}
+
+// End of copied code.
+
+/// Binary logarithm of maximum shuffle size.
+const LG_MAX_SHUFFLE_SIZE: usize = 10;
+/// Maximum shuffle size to benchmark.
+const MAX_SHUFFLE_SIZE: usize = 1 << LG_MAX_SHUFFLE_SIZE;
+
+fn bench_kshuffle_prove(c: &mut Criterion) {
+    // Construct Bulletproof generators externally
+    let pc_gens = PedersenGens::default();
+    let bp_gens = BulletproofGens::new(2 * MAX_SHUFFLE_SIZE, 1);
+
+    #[allow(deprecated)]
+    c.bench_function_over_inputs(
+        "k-shuffle proof creation",
+        move |b, k| {
+            // Generate inputs and outputs to kshuffle
+            let mut rng = rand::thread_rng();
+            let (min, max) = (0u64, std::u64::MAX);
+            let input: Vec<Scalar> = (0..*k)
+                .map(|_| Scalar::from(rng.gen_range(min..max)))
+                .collect();
+            let mut output = input.clone();
+            output.shuffle(&mut rand::thread_rng());
+
+            // Make kshuffle proof
+            b.iter(|| {
+                let mut prover_transcript = Transcript::new(b"ShuffleBenchmark");
+                ShuffleProof::prove(&pc_gens, &bp_gens, &mut prover_transcript, &input, &output)
+                    .unwrap();
+            })
+        },
+        (1..=LG_MAX_SHUFFLE_SIZE)
+            .map(|i| 1 << i)
+            .collect::<Vec<_>>(),
+    );
+}
+
+criterion_group! {
+    name = kshuffle_prove;
+    // Lower the sample size to run faster; larger shuffle sizes are
+    // long so we're not microbenchmarking anyways.
+    config = Criterion::default().sample_size(10);
+    targets =
+    bench_kshuffle_prove,
+}
+
+fn bench_kshuffle_verify(c: &mut Criterion) {
+    // Construct Bulletproof generators externally
+    let pc_gens = PedersenGens::default();
+    let bp_gens = BulletproofGens::new(2 * MAX_SHUFFLE_SIZE, 1);
+
+    #[allow(deprecated)]
+    c.bench_function_over_inputs(
+        "k-shuffle proof verification",
+        move |b, k| {
+            // Generate the proof in its own scope to prevent reuse of
+            // prover variables by the verifier
+            let (proof, input_commitments, output_commitments) = {
+                // Generate inputs and outputs to kshuffle
+                let mut rng = rand::thread_rng();
+                let (min, max) = (0u64, std::u64::MAX);
+                let input: Vec<Scalar> = (0..*k)
+                    .map(|_| Scalar::from(rng.gen_range(min..max)))
+                    .collect();
+                let mut output = input.clone();
+                output.shuffle(&mut rand::thread_rng());
+
+                let mut prover_transcript = Transcript::new(b"ShuffleBenchmark");
+
+                ShuffleProof::prove(&pc_gens, &bp_gens, &mut prover_transcript, &input, &output)
+                    .unwrap()
+            };
+
+            // Verify kshuffle proof
+            b.iter(|| {
+                let mut verifier_transcript = Transcript::new(b"ShuffleBenchmark");
+                proof
+                    .verify(
+                        &pc_gens,
+                        &bp_gens,
+                        &mut verifier_transcript,
+                        &input_commitments,
+                        &output_commitments,
+                    )
+                    .unwrap();
+            })
+        },
+        (1..=LG_MAX_SHUFFLE_SIZE)
+            .map(|i| 1 << i)
+            .collect::<Vec<_>>(),
+    );
+}
+
+criterion_group! {
+    name = kshuffle_verify;
+    // Lower the sample size to run faster; larger shuffle sizes are
+    // long so we're not microbenchmarking anyways.
+    config = Criterion::default().sample_size(10);
+    targets =
+    bench_kshuffle_verify,
+}
+
+criterion_main!(kshuffle_prove, kshuffle_verify);


### PR DESCRIPTION
### Purpose
This PR computes the round reduction -- in which the witness and generators are folded in half via a linear combination of multiplicative inverses -- in parallel using a `rayon` thread pool. Rayon is chosen here to match the implementation in `ark-ec` which is implicitly used in the `StarkPoint::msm` computation.

As well, this PR adds benchmarks for R1CS and IPP prover latency to the repo and measures a large drop in latency after parallelization.

### Testing
- Unit and integration tests pass
- Ran benchmarks, saw a 40-50% decrease in prover latency, especially for large circuits